### PR TITLE
Fix misspelling in german translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -12079,7 +12079,7 @@ msgid ""
 "option."
 msgstr ""
 "oder Sie sich unsicher sind, was das bedeutet, wählen Sie einen anderen "
-"Namenmit der Option '--name'."
+"Namen mit der Option '--name'."
 
 #: git-submodule.sh:347
 #, sh-format


### PR DESCRIPTION
When git proposes to reuse a local git directory the german translation misses a blank midways in "Namenmit".
Added a blank in between.
